### PR TITLE
Remove deprecated stuff

### DIFF
--- a/espressif/esp32-espidf-hello-world/src/main.c
+++ b/espressif/esp32-espidf-hello-world/src/main.c
@@ -21,12 +21,11 @@ void hello_task(void *pvParameter)
     }
     printf("Restarting now.\n");
     fflush(stdout);
-    system_restart();
+    esp_restart();
 }
 
 void app_main()
 {
     nvs_flash_init();
-    system_init();
     xTaskCreate(&hello_task, "hello_task", 2048, NULL, 5, NULL);
 }


### PR DESCRIPTION
This example uses deprecated stuff which will be removed in a future release of ESP-IDF.
The `system_init()` is deprecated and do nothing. An application don't need to call this function anymore.
The `system_restart()` is also deprecated and a new one should be used `esp_restart()`.

I've built and tested it with Lolin32 board.