### PR TITLE
Initial commit of 1Bitsy locm3 fancyblink example.

### DIFF
--- a/1bitsy/fancyblink/.gitignore
+++ b/1bitsy/fancyblink/.gitignore
@@ -1,0 +1,4 @@
+.pioenvs
+.piolibdeps
+.clang_complete
+.gcc-flags.json

--- a/1bitsy/fancyblink/.travis.yml
+++ b/1bitsy/fancyblink/.travis.yml
@@ -1,0 +1,65 @@
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < http://docs.platformio.org/page/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < http://docs.platformio.org/page/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < http://docs.platformio.org/page/userguide/cmd_ci.html >
+#
+#
+# Please choice one of the following templates (proposed below) and uncomment
+# it (remove "# " before each line) or use own configuration according to the
+# Travis CI documentation (see above).
+#
+
+
+#
+# Template #1: General project. Test it using existing `platformio.ini`.
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# install:
+#     - pip install -U platformio
+#
+# script:
+#     - platformio run
+
+
+#
+# Template #2: The project is intended to by used as a library with examples
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# env:
+#     - PLATFORMIO_CI_SRC=path/to/test/file.c
+#     - PLATFORMIO_CI_SRC=examples/file.ino
+#     - PLATFORMIO_CI_SRC=path/to/test/directory
+#
+# install:
+#     - pip install -U platformio
+#
+# script:
+#     - platformio ci --lib="." --board=ID_1 --board=ID_2 --board=ID_N

--- a/1bitsy/fancyblink/README.rst
+++ b/1bitsy/fancyblink/README.rst
@@ -1,0 +1,40 @@
+README
+======
+
+This is the smallest-possible example program using libopencm3.
+
+It's intended for the 1Bitsy STM32F415RGT eval board. It should blink
+the LED on the board.
+
+Board connections
+=================
+
+*none required*
+
+How to build PlatformIO based project
+=====================================
+
+1. `Install PlatformIO Core <http://docs.platformio.org/page/core.html>`_
+2. Download `examples source code <https://github.com/platformio/platformio-examples/archive/develop.zip>`_
+3. Extract ZIP archive
+4. Run these commands:
+
+.. code-block:: bash
+
+    # Change directory to example
+    > cd platformio-examples/1bitsy/fancyblink
+
+    # Build project
+    > platformio run
+
+    # Upload firmware
+    > platformio run --target upload
+
+    # Build specific environment
+    > platformio run -e 1bitsy_stm32f415rgt
+
+    # Upload firmware for the specific environment
+    > platformio run -e 1bitsy_stm32f415rgt --target upload
+
+    # Clean build files
+    > platformio run --target clean

--- a/1bitsy/fancyblink/lib/readme.txt
+++ b/1bitsy/fancyblink/lib/readme.txt
@@ -1,0 +1,36 @@
+
+This directory is intended for the project specific (private) libraries.
+PlatformIO will compile them to static libraries and link to executable file.
+
+The source code of each library should be placed in separate directory, like
+"lib/private_lib/[here are source files]".
+
+For example, see how can be organized `Foo` and `Bar` libraries:
+
+|--lib
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |- readme.txt --> THIS FILE
+|- platformio.ini
+|--src
+   |- main.c
+
+Then in `src/main.c` you should use:
+
+#include <Foo.h>
+#include <Bar.h>
+
+// rest H/C/CPP code
+
+PlatformIO will find your libraries automatically, configure preprocessor's
+include paths and build them.
+
+More information about PlatformIO Library Dependency Finder
+- http://docs.platformio.org/page/librarymanager/ldf.html

--- a/1bitsy/fancyblink/platformio.ini
+++ b/1bitsy/fancyblink/platformio.ini
@@ -1,0 +1,16 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[env:1bitsy]
+board = 1bitsy_stm32f415rgt
+platform = ststm32
+framework = libopencm3
+debug_tool = blackmagic
+debug_port = /dev/cu.usbmodem7ABA58A1

--- a/1bitsy/fancyblink/src/button_boot.c
+++ b/1bitsy/fancyblink/src/button_boot.c
@@ -1,0 +1,45 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2016 Piotr Esden-Tempski <piotr@esden.net>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/cm3/scb.h>
+
+#include "button_boot.h"
+
+#define BLDR_ADDRESS	0x1FFF0000
+
+void button_boot(void) {
+  /* Enable GPIOC clock. */
+	rcc_periph_clock_enable(RCC_GPIOC);
+
+	/* Set GPIO1 (in GPIO port C) to 'input open-drain'. */
+	gpio_mode_setup(GPIOC, GPIO_MODE_INPUT, GPIO_PUPD_NONE, GPIO1);
+
+  /* Check if the user button is depressed, if so launch the factory bootloader */
+  if ((GPIOC_IDR & (1 << 1)) == 0) {
+		/* Set vector table base address. */
+		SCB_VTOR = BLDR_ADDRESS & 0xFFFF;
+		/* Initialise master stack pointer. */
+		asm volatile("msr msp, %0"::"g"
+				 (*(volatile uint32_t *)BLDR_ADDRESS));
+		/* Jump to bootloader. */
+		(*(void (**)())(BLDR_ADDRESS + 4))();
+	}
+}

--- a/1bitsy/fancyblink/src/button_boot.h
+++ b/1bitsy/fancyblink/src/button_boot.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2016 Piotr Esden-Tempski <piotr@esden.net>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COMMON_BUTTON_BOOT_H
+#define COMMON_BUTTON_BOOT_H
+
+/* This function sets up and checks the state of the user button.
+ * If the user button is depressed the built in factory bootloader is launched.
+ */
+void button_boot(void);
+
+#endif /* COMMON_BUTTON_BOOT_H */

--- a/1bitsy/fancyblink/src/main.c
+++ b/1bitsy/fancyblink/src/main.c
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Damjan Marion <damjan.marion@gmail.com>
+ * Copyright (C) 2011 Mark Panajotovic <marko@electrontube.org>
+ * Copyright (C) 2016 Piotr Esden-Tempski <piotr@esden.net>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "button_boot.h"
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+
+/* Set STM32 to 168 MHz. */
+static void clock_setup(void)
+{
+	rcc_clock_setup_hse_3v3(&hse_25mhz_3v3[CLOCK_3V3_168MHZ]);
+
+	/* Enable GPIOA clock. */
+	rcc_periph_clock_enable(RCC_GPIOA);
+}
+
+static void gpio_setup(void)
+{
+	/* Set GPIO8 (in GPIO port A) to 'output push-pull'. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_OUTPUT,
+			GPIO_PUPD_NONE, GPIO8);
+}
+
+int main(void)
+{
+	int i;
+
+	button_boot();
+
+	clock_setup();
+	gpio_setup();
+
+	/* Set two LEDs for wigwag effect when toggling. */
+	gpio_set(GPIOA, GPIO8);
+
+	/* Blink the LEDs (PA8) on the board. */
+	while (1) {
+		/* Toggle LEDs. */
+		gpio_toggle(GPIOA, GPIO8);
+		for (i = 0; i < 6000000; i++) { /* Wait a bit. */
+			__asm__("nop");
+		}
+	}
+
+	return 0;
+}

--- a/1bitsy/fancyblink/upload.gdb
+++ b/1bitsy/fancyblink/upload.gdb
@@ -1,0 +1,7 @@
+target ext /dev/cu.usbmodem7ABA58A1
+monitor version
+monitor swdp_scan
+attach 1
+load
+compare-sections
+kill


### PR DESCRIPTION
Uses Black Magic Probe for upload and debug targets.

This example and pull request relies on platformio/platform-ststm32#67

Note: I am not sure what the right approach is to autodetect the first serial port of the Black Magic Probe. It would be good if there was a way to provide a default `debug_port` and the equivalent `target extended_remote` port for gdb to use. The original locm3 1bitsy examples can at least autodetect the uart port on a linux and Mac OS hosts. https://github.com/1Bitsy/1bitsy-examples/blob/master/examples/Makefile.rules#L254 There might be a good way to do that on windows too, but hardcoding it in the project files is probably not the best solution, especially when the project is being worked on by more than one person or computers.