### PR TITLE
unit-testing/stm32cube: Add missing SysTick_Handler to unittest_transport.c

### DIFF
--- a/unit-testing/stm32cube/test/test_main.c
+++ b/unit-testing/stm32cube/test/test_main.c
@@ -64,3 +64,7 @@ int main() {
 
     while(1){}
 }
+
+void SysTick_Handler(void) {
+  HAL_IncTick();
+}

--- a/unit-testing/stm32cube/test/unittest_transport.c
+++ b/unit-testing/stm32cube/test/unittest_transport.c
@@ -86,3 +86,7 @@ void unittest_uart_end() {
   USARTx_RX_GPIO_CLK_DISABLE();
   USARTx_TX_GPIO_CLK_DISABLE();
 }
+
+void SysTick_Handler(void) {
+  HAL_IncTick();
+}

--- a/unit-testing/stm32cube/test/unittest_transport.c
+++ b/unit-testing/stm32cube/test/unittest_transport.c
@@ -86,7 +86,3 @@ void unittest_uart_end() {
   USARTx_RX_GPIO_CLK_DISABLE();
   USARTx_TX_GPIO_CLK_DISABLE();
 }
-
-void SysTick_Handler(void) {
-  HAL_IncTick();
-}


### PR DESCRIPTION
# Problem
Unit tests doesn't work on my Nucleo F767-ZI.
Always stuck at 

> Testing...
> If you don't see any output for the first 10 secs, please reset board (press reset button)

And yes, i pressed the reset button.

# Solution
After adding SysTick_Handler to unittest_transport.c the Unittest working as expected.

Maybe that's not the best location for SysTick_Handler or I missed it elsewere.
I am just a Newbie. Started with platformio today and just playing around with my ST board when its raining.