### PR TITLE
Correction to issue #34

### DIFF
--- a/unit-testing/arduino-mock/platformio.ini
+++ b/unit-testing/arduino-mock/platformio.ini
@@ -10,5 +10,6 @@
 [env:native]
 platform = native
 build_flags = -std=gnu++11
+lib_compat_mode = off
 lib_deps =
     ArduinoFake


### PR DESCRIPTION
When using native and ArduinoFake, it is necessary to use lib_compat_mode = off