### PR TITLE
Updated openocd 0.12 script path

### DIFF
--- a/unit-testing/semihosting/platformio.ini
+++ b/unit-testing/semihosting/platformio.ini
@@ -27,7 +27,7 @@ test_testing_command =
     -s
     ${platformio.packages_dir}/tool-openocd
     -f
-    scripts/board/st_nucleo_l1.cfg
+    openocd/scripts/board/st_nucleo_l1.cfg
     -c
     init
     -c


### PR DESCRIPTION
The path is different now. Probably due to OpenOCD 0.12.