### PR TITLE
Use angle brackets for standard library Arduino.h

### DIFF
--- a/wiring-blink/src/main.cpp
+++ b/wiring-blink/src/main.cpp
@@ -4,9 +4,9 @@
  * then off for one second, repeatedly.
  */
 
-#include "Arduino.h"
+#include <Arduino.h>
 
-// Set LED_BUILTIN if it is not defined by Arduino framework
+// Set LED_BUILTIN if it is not defined by the Arduino framework
 // #define LED_BUILTIN 13
 
 void setup()


### PR DESCRIPTION
Arduino.h is a standard library, therefore angle brackets should be used and not quotations when including it.